### PR TITLE
Update uci frontend labels - assessments

### DIFF
--- a/roles/upgrade_aspace_software/files/uci-en-frontend.yml
+++ b/roles/upgrade_aspace_software/files/uci-en-frontend.yml
@@ -179,6 +179,16 @@ en:
       location_profile_depth_u_sstr: Depth
       location_profile_dimension_units_u_sstr: Dimension Units
       rights_statement_agent_uris: Rights Statement Agent
+      assessment_surveyors: Surveyed By
+      assessment_review_required: Review Required
+      assessment_sensitive_material: Sensitive Material
+      assessment_reviewer_uris: Reviewer
+      assessment_surveyed_by_uris: Surveyed By
+      assessment_reviewers: Reviewer
+      assessment_inactive: Inactive
+      assessment_survey_year: Survey Year
+      assessment_record_types: Record Type
+      assessment_completed: Completed
     help:
       row_selection: Click a row to select it for bulk operations. Hold alt while clicking a checkbox to select, or unselect, multple previous rows.
 
@@ -222,6 +232,9 @@ en:
     digital_object_type: Digital Object Type
     publish: Publish
     location_profile_display_string_u_ssort: Location Profile
+    assessment_survey_begin: Survey Begin Date
+    assessment_survey_end: Survey Completed Date
+    assessment_id: ID
 
   advanced_search:
     operator:
@@ -294,6 +307,7 @@ en:
     global_admin: System
     system_info: System Information
     unpublished: Unpublished
+    manage_assessment_attributes: Manage Assessment Attributes
   session:
     gone: Your backend session was not found
     expired: Your session expired due to inactivity
@@ -312,6 +326,9 @@ en:
     locations:
       success: Locations deleted
       error: "Unable to delete locations:"
+    assessments:
+      success: Assessments deleted
+      error: "Unable to delete assessments:"
 
   welcome:
     heading: Welcome to UCI Special Collections and Archives
@@ -390,6 +407,7 @@ en:
     error_404: Record Not Found
     error_404_message: "The record you've tried to access may no longer exist or you may not have permission to view it."
     error_tree_pane_ajax: An error occurred loading this form.
+    linked_to_assessment: Record cannot be deleted as it is linked to an assessment
 
   accession:
     _frontend:
@@ -1296,3 +1314,80 @@ en:
     _frontend:
       action:
         add: Add Act
+        
+    assessment:
+    _frontend:
+      form_header: Assessment %{display_string}
+      formats: Material Types / Formats
+      ratings: Ratings
+      conservation_issues: Conservation Issues
+      record_types: Record Types
+      action:
+        create: Create Assessment
+        save: Save Assessment
+        add_rating_note: Add Note
+        remove_rating_note: Remove Note
+        create_for_record: Create Assessment
+      section:
+        basic_information: Basic Information
+        existing_description: Existing Description
+        rating_attributes: Assessment Information
+        rating_attributes_empty: No assessment information entered
+        rating_attributes_additional: Additional Rating(s)
+        format_attributes: List of Material Types / Formats
+        format_attributes_empty: No material types / formats entered
+        format_attributes_additional: Additional Material Types / Formats
+        conservation_issue_attributes: Conservation Issues
+        conservation_issue_attributes_empty: No conservation issues entered
+        conservation_issue_attributes_additional: Additional Conservation Issues
+      messages:
+        created: Assessment Created
+        updated: Assessment Updated
+        deleted: Assessment Deleted
+        attributes_hint: Please contact your administrator to add additional %{attribute_type}
+        manage_attributes_hint: Manage the additional %{attribute_type} for this repository
+      assessment_review_required:
+        true_value: "Yes"
+        false_value: "No"
+      assessment_sensitive_material:
+        true_value: "Yes"
+        false_value: "No"
+      assessment_inactive:
+        true_value: "Yes"
+        false_value: "No"
+      assessment_completed:
+        true_value: "Yes"
+        false_value: "No"
+      browse_reviewers: Reviewers
+      linked_records:
+        heading: Linked Records
+        loading: Loading...
+        linked_via_assessment_records: Assessments
+        linked_via_assessment_surveyed_by: Assessments - Surveyed By
+        linked_via_assessment_reviewer: Assessments - Reviewer
+        record_type: Record Type
+        title: Title
+        identifier: Identifier
+      ratings_list:
+        rating: Rating
+        score: Score
+        note: Note
+
+  assessment_attribute_definitions:
+    _frontend:
+      title: Assessment Attributes
+      section:
+        formats: Material Types / Formats
+        ratings: Ratings
+        conservation_issues: Conservation Issues
+      global: Global %{type}
+      repository: Repository %{type}
+      action:
+        save: Save Assessment Attributes
+      messages:
+        updated: Assessment Attributes updated
+        error: Error updating Assessment Attributes
+        conflict: "Error updating Assessment Attributes. The following labels conflict with existing entries: %{conflicts}"
+        attribute_in_use: Unable to delete an attribute that is currently in use by an assessment
+      database_value: Database Value
+      translation: Translation


### PR DESCRIPTION
Added in all assessment labels and definitions (form fields, drop downs, error messages) and mapped them to the appropriate sections to mirror ASpace's "out of the box" yml. "Assessment" now shows up 47 times, matching ASpace.